### PR TITLE
channel.c: Protect the process from unwanted network connections

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -1513,6 +1513,12 @@ channel_listen(
     int			val = 1;
     channel_T		*channel;
 
+    if (hostname == NULL || *hostname == NUL)
+    {
+	ch_error(NULL, "Hostname/address not defined.");
+	return NULL;
+    }
+
 #ifdef MSWIN
     channel_init_winsock();
 #endif
@@ -1521,12 +1527,6 @@ channel_listen(
     if (channel == NULL)
     {
 	ch_error(NULL, "Cannot allocate channel.");
-	return NULL;
-    }
-
-    if (hostname == NULL || *hostname == NUL)
-    {
-	ch_error(NULL, "Hostname/address not defined.");
 	return NULL;
     }
 
@@ -1571,6 +1571,15 @@ channel_listen(
     memcpy(&p, &host->h_addr_list[0], sizeof(p));
     memcpy((char *)&server.sin_addr, p, host->h_length);
 #endif
+
+    // Check if the resolved address is among loopback scope (subnet 127.0.0.0/8)
+    // Once there is IPv6 support, update this for IPv6.
+    if ((ntohl(server.sin_addr.s_addr) & 0xFF000000) != 0x7F000000)
+    {
+	ch_error(NULL, "Listening loopback-only.");
+	channel_free(channel);
+	return NULL;
+    }
 
     sd = socket(AF_INET, SOCK_STREAM, 0);
     if (sd == -1)

--- a/src/channel.c
+++ b/src/channel.c
@@ -1524,52 +1524,53 @@ channel_listen(
 	return NULL;
     }
 
+    if (hostname == NULL || *hostname == NUL)
+    {
+	ch_error(NULL, "Hostname/address not defined.");
+	return NULL;
+    }
+
     // Get the server internet address and put into addr structure
     // fill in the socket address structure and bind to port
     vim_memset((char *)&server, 0, sizeof(server));
     server.sin_family = AF_INET;
     server.sin_port = htons(port_in);
-    if (hostname != NULL && *hostname != NUL)
-    {
+
 #ifdef FEAT_IPV6
-	struct addrinfo	hints;
-	struct addrinfo	*res = NULL;
-	int		err;
+    struct addrinfo	hints;
+    struct addrinfo	*res = NULL;
+    int		err;
 
-	CLEAR_FIELD(hints);
-	hints.ai_family = AF_INET;
-	hints.ai_socktype = SOCK_STREAM;
-	if ((err = getaddrinfo(hostname, NULL, &hints, &res)) != 0)
-	{
-	    ch_error(channel, "in getaddrinfo() in channel_listen()");
-	    PERROR(_(e_gethostbyname_in_channel_listen));
-	    channel_free(channel);
-	    return NULL;
-	}
-	memcpy(&server.sin_addr,
-		&((struct sockaddr_in *)res->ai_addr)->sin_addr,
-		sizeof(server.sin_addr));
-	freeaddrinfo(res);
-#else
-	if ((host = gethostbyname(hostname)) == NULL)
-	{
-	    ch_error(channel, "in gethostbyname() in channel_listen()");
-	    PERROR(_(e_gethostbyname_in_channel_listen));
-	    channel_free(channel);
-	    return NULL;
-	}
-	{
-	    char		*p;
-
-	    // When using host->h_addr_list[0] directly ubsan warns for it to
-	    // not be aligned.  First copy the pointer to avoid that.
-	    memcpy(&p, &host->h_addr_list[0], sizeof(p));
-	    memcpy((char *)&server.sin_addr, p, host->h_length);
-	}
-#endif
+    CLEAR_FIELD(hints);
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    if ((err = getaddrinfo(hostname, NULL, &hints, &res)) != 0)
+    {
+	ch_error(channel, "in getaddrinfo() in channel_listen()");
+	PERROR(_(e_gethostbyname_in_channel_listen));
+	channel_free(channel);
+	return NULL;
     }
-    else
-	server.sin_addr.s_addr = htonl(INADDR_ANY);
+    memcpy(&server.sin_addr,
+	&((struct sockaddr_in *)res->ai_addr)->sin_addr,
+	sizeof(server.sin_addr));
+    freeaddrinfo(res);
+#else
+    if ((host = gethostbyname(hostname)) == NULL)
+    {
+	ch_error(channel, "in gethostbyname() in channel_listen()");
+	PERROR(_(e_gethostbyname_in_channel_listen));
+	channel_free(channel);
+	return NULL;
+    }
+
+    char		*p;
+
+    // When using host->h_addr_list[0] directly ubsan warns for it to
+    // not be aligned.  First copy the pointer to avoid that.
+    memcpy(&p, &host->h_addr_list[0], sizeof(p));
+    memcpy((char *)&server.sin_addr, p, host->h_length);
+#endif
 
     sd = socket(AF_INET, SOCK_STREAM, 0);
     if (sd == -1)


### PR DESCRIPTION
The MR includes two fixes:

* removal of INADDR_ANY, which would make Vim bind to any network interface on the machine, possibly opening the process to network,
* make ch_listen to work only in localhost, which narrows the attack vector of any exploits using Vim vulnerabilities.

It would be great if both commits were added to the project, but if the latter is desired behavior, the former would be good to fix.

The proper firewall settings do protect system from such attacks, but IMO it is preferable to avoid such dependencies if it is possible and makes sense.

Thank you in advance!

Zdenek